### PR TITLE
adding git submodules to vendor directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/gopkg.in/dgrijalva/jwt-go.v2"]
+	path = vendor/gopkg.in/dgrijalva/jwt-go.v2
+	url = https://github.com/dgrijalva/jwt-go.git

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Use this to help minimize the code in your apps that use jwt tokens.
 
 ### Getting Started
 You'll need to have a few things installed in order to work with this package.
-- [Golang](https://golang.org/doc/install)
+- [Golang](https://golang.org/doc/install) Version 1.6 is preferred. If using
+version 1.5, then set the environment variable, GO15VENDOREXPERIMENT=1.  This is
+required to build, install and test code using this package.
 
 Get started by cloning down the repo that you will need:
 ```shell


### PR DESCRIPTION
- Store the dependencies into the vendor directory as git submodules.
- Update README.md, to reflect this change, with short explanation.
